### PR TITLE
Debugger displays primitive values incorrectly in tooltips

### DIFF
--- a/evaluators/debugnode.js
+++ b/evaluators/debugnode.js
@@ -404,45 +404,55 @@ define(function(require, exports, module) {
                     
                     caption = document.createElement("span");
                     insert(caption, heading, name);
+                    insertTree(html, caption, object, parseChildren);
                 }
                 else {
-                    heading = (object.value || "[(anonymous function)]")
-                        .replace(/^\[(.*)\]$/, "$1");
-                    if (short === true) 
-                        return insert(html, heading, name);
-                
-                    caption = document.createElement("span");
-                    insert(caption, heading, name);
-                    preview = caption.appendChild(document.createElement("span"));
-                    preview.className = "preview";
-                    
-                    if (short !== 2) {
-                        insert(preview, " {");
-                        
-                        props = object.properties || [];
-                        count = 0;
-                        for (var i = 0; count < 5 && i < props.length; i++) {
-                            var propName = props[i].name;
-                            // for buffers propName is a number
-                            if (typeof propName == "string" && propName.indexOf("function") === 0)
-                                continue;
+                    if (type === "object" || object.properties.length > 0) {
+                        // An object, or a value of unknown type which has properties, so should be displayed as an object.
 
-                            insert(preview, (i !== 0 ? ", " : ""));
-                            insert(preview, "", propName);
-                            renderType(props[i], preview, 2, true);
-                            count++;
+                        heading = (object.value || "[(anonymous function)]")
+                            .replace(/^\[(.*)\]$/, "$1");
+                        if (short === true)
+                            return insert(html, heading, name);
+
+                        caption = document.createElement("span");
+                        insert(caption, heading, name);
+                        preview = caption.appendChild(document.createElement("span"));
+                        preview.className = "preview";
+
+                        if (short !== 2) {
+                            insert(preview, " {");
+
+                            props = object.properties || [];
+                            count = 0;
+                            for (var i = 0; count < 5 && i < props.length; i++) {
+                                var propName = props[i].name;
+                                // for buffers propName is a number
+                                if (typeof propName == "string" && propName.indexOf("function") === 0)
+                                    continue;
+
+                                insert(preview, (i !== 0 ? ", " : ""));
+                                insert(preview, "", propName);
+                                renderType(props[i], preview, 2, true);
+                                count++;
+                            }
+                            if (props.length > count)
+                                insert(preview, "…");
+
+                            insert(preview, "}");
                         }
-                        if (props.length > count)
-                            insert(preview, "…");
-                            
-                        insert(preview, "}");
+                        else {
+                            insert(preview, "");
+                        }
+
+                        insertTree(html, caption, object, parseChildren);
                     }
                     else {
-                        insert(preview, "");
+                        // A value of unknown type which does not have any properties - assume it is a language-specific
+                        // primitive type.
+                        insert(html, value, name);
                     }
                 }
-                
-                insertTree(html, caption, object, parseChildren);
             }
         }
         


### PR DESCRIPTION
We have written a debugger for our custom modeling language. When stopped at a breakpoint, if I hover the mouse over a variable in a source file, the value is displayed. However, if the value is a primitive type, it has a menu icon before it and a pair of braces after it, e.g., `5 {}`.

This is because `debugnode.js` hard-codes which type names have/don't have properties that can be expanded, and the type names of our custom language are not in the list, e.g., `real` and `integer`. I don't want to change our type names because then they will appear incorrectly in the local variables and watches pane (people will get confused if they declare a variable using `real` in the source code but it displays as `float` in the debugger).

@javruben As discussed in https://groups.google.com/forum/#!topic/cloud9-sdk/BcgP_Bchb4U, this is my first attempt at fixing it.

The logic for how to display the tooltip is:
- If the type is a known primitive type, display as a primitive as before.
- If the type is `"object"`, display as an object.
- If the value has properties, display as an object.
- Otherwise (the type is unknown and it has no properties), display as a primitive.
