### PR TITLE
Fix: check that object.properties exists before testing its length

### DIFF
--- a/evaluators/debugnode.js
+++ b/evaluators/debugnode.js
@@ -407,7 +407,7 @@ define(function(require, exports, module) {
                     insertTree(html, caption, object, parseChildren);
                 }
                 else {
-                    if (type === "object" || object.properties.length > 0) {
+                    if (type === "object" || (object.properties && object.properties.length > 0)) {
                         // An object, or a value of unknown type which has properties, so should be displayed as an object.
 
                         heading = (object.value || "[(anonymous function)]")


### PR DESCRIPTION
Fixes a null reference error in my previous pull request: https://github.com/c9/c9.ide.immediate/pull/1