### PR TITLE
Allow debug nodes which have lazily-loaded children to be expanded when shown in a tooltip

### DIFF
--- a/evaluators/debugnode.js
+++ b/evaluators/debugnode.js
@@ -407,7 +407,7 @@ define(function(require, exports, module) {
                     insertTree(html, caption, object, parseChildren);
                 }
                 else {
-                    if (type === "object" || (object.properties && object.properties.length > 0)) {
+                    if (type === "object" || object.children || (object.properties && object.properties.length > 0)) {
                         // An object, or a value of unknown type which has properties, so should be displayed as an object.
 
                         heading = (object.value || "[(anonymous function)]")


### PR DESCRIPTION
Fixes an issue where mousing over an object in a source file when paused in the debugger does not allow you to keep expanding the properties of the object, and the properties of the properties, etc., in the case where the object's properties are loaded on demand.
